### PR TITLE
generate sources and javadoc jar artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,30 @@
           <target>1.6</target>
         </configuration>
       </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Hi Ian,

I've amended the maven config to generate neode-1.0-sources.jar and neode-1.0-javadoc.jar in order to have docs and source right at hand when neode is use from other projects.

Cheers,
Stefan
